### PR TITLE
Fix/code sniffer magento2 dev

### DIFF
--- a/Model/Message/ConfigNotification.php
+++ b/Model/Message/ConfigNotification.php
@@ -80,7 +80,7 @@ class ConfigNotification implements MessageInterface
      */
     public function getIdentity()
     {
-        return md5('AVATAX_CONFIG_NOTIFICATION');
+        return sha1('AVATAX_CONFIG_NOTIFICATION');
     }
 
     /**

--- a/Model/Message/QueueDisabledNotification.php
+++ b/Model/Message/QueueDisabledNotification.php
@@ -70,7 +70,7 @@ class QueueDisabledNotification implements MessageInterface
      */
     public function getIdentity()
     {
-        return md5('AVATAX_QUEUE_DISABLED_NOTIFICATION');
+        return sha1('AVATAX_QUEUE_DISABLED_NOTIFICATION');
     }
 
     /**

--- a/Model/Message/QueueFailureNotification.php
+++ b/Model/Message/QueueFailureNotification.php
@@ -91,7 +91,7 @@ class QueueFailureNotification implements MessageInterface
     {
         // Each week there are failures would introduce a new identity for the Message
         // and prompt the admin user to acknowledge the notification.
-        return md5('AVATAX_QUEUE_FAILURE_' . implode(':', array_keys($this->getQueueFailureStats())));
+        return sha1('AVATAX_QUEUE_FAILURE_' . implode(':', array_keys($this->getQueueFailureStats())));
     }
 
     /**

--- a/Model/Message/QueueNotification.php
+++ b/Model/Message/QueueNotification.php
@@ -94,7 +94,7 @@ class QueueNotification implements MessageInterface
      */
     public function getIdentity()
     {
-        return md5('AVATAX_QUEUE_NOTIFICATION');
+        return sha1('AVATAX_QUEUE_NOTIFICATION');
     }
 
     /**

--- a/Model/Tax/Sales/Total/Quote/Tax.php
+++ b/Model/Tax/Sales/Total/Quote/Tax.php
@@ -15,8 +15,8 @@
 
 namespace ClassyLlama\AvaTax\Model\Tax\Sales\Total\Quote;
 
-use ClassyLlama\AvaTax\Framework\Interaction\Tax\Get\Proxy as InteractionGet;
-use ClassyLlama\AvaTax\Framework\Interaction\TaxCalculation\Proxy as TaxCalculation;
+use ClassyLlama\AvaTax\Framework\Interaction\Tax\Get as InteractionGet;
+use ClassyLlama\AvaTax\Framework\Interaction\TaxCalculation as TaxCalculation;
 use ClassyLlama\AvaTax\Helper\Config;
 use ClassyLlama\AvaTax\Model\Tax\Sales\Total\Quote\Tax\Customs as CustomsTax;
 use Magento\Customer\Api\Data\AddressInterfaceFactory as CustomerAddressFactory;

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -287,4 +287,11 @@
     <type name="Magento\Customer\Controller\Account\CreatePost">
         <plugin sortOrder="1" name="classyLlamaAvaTaxCreatePost" type="ClassyLlama\AvaTax\Plugin\Controller\Account\CreatePostPlugin"/>
     </type>
+
+    <type name="ClassyLlama\AvaTax\Model\Tax\Sales\Total\Quote\Tax">
+        <arguments>
+            <argument name="interactionGetTax" xsi:type="object">ClassyLlama\AvaTax\Framework\Interaction\Tax\Get\Proxy</argument>
+            <argument name="taxCalculation" xsi:type="object">ClassyLlama\AvaTax\Framework\Interaction\TaxCalculation\Proxy</argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Code Sniffer by Magento2;
- Proxies and interceptors MUST never be explicitly requested in constructors;
- The use of function md5() is forbidden; use improved hash functions (SHA-256, SHA-512, SHA1 etc.) instead